### PR TITLE
numerical stable exp_conv_cauchy try3

### DIFF
--- a/src/TRXASprefitpack/mathfun/mathfun.py
+++ b/src/TRXASprefitpack/mathfun/mathfun.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import scipy.linalg as LA
-from scipy.special import erf, exp1
+from scipy.special import erf, exp1, expi
 
 
 def exp_conv_gau(t, fwhm, k):
@@ -92,7 +92,7 @@ def exp_conv_cauchy(t, fwhm, k):
         ikgamma = complex(0, k*gamma)
         kt = k*t
         ans = np.exp(-ikgamma)*exp1(-kt-ikgamma)
-        ans = np.exp(-kt)*ans.imag
+        ans = np.exp(-kt)*ans.imag/np.pi
     return ans
 
 

--- a/src/TRXASprefitpack/mathfun/mathfun.py
+++ b/src/TRXASprefitpack/mathfun/mathfun.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import scipy.linalg as LA
-from scipy.special import erf, exp1, expi
+from scipy.special import erf, exp1
 
 
 def exp_conv_gau(t, fwhm, k):

--- a/src/TRXASprefitpack/mathfun/mathfun.py
+++ b/src/TRXASprefitpack/mathfun/mathfun.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import scipy.linalg as LA
-from scipy.special import erf, expi
+from scipy.special import erf, exp1
 
 
 def exp_conv_gau(t, fwhm, k):
@@ -79,7 +79,7 @@ def exp_conv_cauchy(t, fwhm, k):
     :return: convolution of normalized cauchy distribution and exp(-kt)
 
     .. math::
-       \\frac{\\exp(-kt)}{\\pi}\\Im\\left(\\exp(-ik\\gamma)\cdot\\left(i\\pi - {Ei}\\left(kt+ik\gamma\\right)\\right)\\right)
+       \\frac{\\exp(-kt)}{\\pi}\\Im\\left(\\exp(-ik\\gamma)\cdot{E1}(-kt-ik\\gamma)\\right)
 
 
     :rtype: numpy_1d_array 
@@ -89,18 +89,10 @@ def exp_conv_cauchy(t, fwhm, k):
     if k == 0:
         ans = 0.5+1/np.pi*np.arctan(t/gamma)
     else:
-        kgamma = k*gamma
+        ikgamma = complex(0, k*gamma)
         kt = k*t
-        ans = complex(0, 1)-expi(kt+complex(0, kgamma))/np.pi
-        if len(ans.shape) == 0:
-            if np.abs(ans.imag) < 1e-12:
-                ans = 0
-            else:
-                pass
-        else:
-            ans[np.abs(ans.imag) < 1e-12] = 0
-        ans = -np.sin(kgamma)*ans.real + np.cos(kgamma)*ans.imag
-        ans = np.exp(-kt)*ans
+        ans = np.exp(-ikgamma)*exp1(-kt-ikgamma)
+        ans = np.exp(-kt)*ans.imag
     return ans
 
 


### PR DESCRIPTION
Note that
ipi - Ei(kt+ikr) = E1(-kt-ikr)
and E1 is more numerical stable then ipi-Ei(kt+ikr) at t < 0
![old_new_compare](https://user-images.githubusercontent.com/41019538/135700521-c585daf0-3ac7-4b59-bf88-5d124a80a387.png)
Note (IRF: 0.15 and lifetime: 0.83)
