### PR TITLE
fix test case containing oscillation features

### DIFF
--- a/tests/test_driver_transient_both_1.py
+++ b/tests/test_driver_transient_both_1.py
@@ -26,14 +26,13 @@ def test_driver_transient_both_1():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
     eigval_seq, V_seq, c_seq = solve_seq_model(np.array([tau_1, tau_2, tau_3]), y0)
 
     # Now generates measured transient signal

--- a/tests/test_driver_transient_both_2.py
+++ b/tests/test_driver_transient_both_2.py
@@ -26,14 +26,13 @@ def test_driver_transient_both_2():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
     eigval_seq, V_seq, c_seq = solve_seq_model(np.array([tau_1, tau_2, tau_3]), y0)
 
     # Now generates measured transient signal

--- a/tests/test_driver_transient_both_3.py
+++ b/tests/test_driver_transient_both_3.py
@@ -30,14 +30,13 @@ def test_driver_transient_both_3():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
     eigval_seq, V_seq, c_seq = solve_seq_model(np.array([tau_1, tau_2, tau_3]), y0)
 
     # Now generates measured transient signal

--- a/tests/test_driver_transient_both_4.py
+++ b/tests/test_driver_transient_both_4.py
@@ -26,14 +26,13 @@ def test_driver_transient_both_4():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
     eigval_seq, V_seq, c_seq = solve_seq_model(np.array([tau_1, tau_2, tau_3]), y0)
 
     # Now generates measured transient signal

--- a/tests/test_driver_transient_both_5.py
+++ b/tests/test_driver_transient_both_5.py
@@ -26,14 +26,13 @@ def test_driver_transient_both_5():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
     eigval_seq, V_seq, c_seq = solve_seq_model(np.array([tau_1, tau_2, tau_3]), y0)
 
     # Now generates measured transient signal

--- a/tests/test_driver_transient_both_6.py
+++ b/tests/test_driver_transient_both_6.py
@@ -30,14 +30,13 @@ def test_driver_transient_both_6():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
     eigval_seq, V_seq, c_seq = solve_seq_model(np.array([tau_1, tau_2, tau_3]), y0)
 
     # Now generates measured transient signal

--- a/tests/test_driver_transient_dmp_osc_1.py
+++ b/tests/test_driver_transient_dmp_osc_1.py
@@ -21,14 +21,13 @@ def test_driver_transient_dmp_osc_1():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
 
     # Now generates measured transient signal
     # Last element is ground state

--- a/tests/test_driver_transient_dmp_osc_2.py
+++ b/tests/test_driver_transient_dmp_osc_2.py
@@ -21,14 +21,13 @@ def test_driver_transient_dmp_osc_2():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
 
     # Now generates measured transient signal
     # Last element is ground state

--- a/tests/test_driver_transient_dmp_osc_3.py
+++ b/tests/test_driver_transient_dmp_osc_3.py
@@ -25,15 +25,13 @@ def test_driver_transient_dmp_osc_3():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
-
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
     # Now generates measured transient signal
     # Last element is ground state
     abs_1 = np.array([1, 1, 1])

--- a/tests/test_driver_transient_dmp_osc_4.py
+++ b/tests/test_driver_transient_dmp_osc_4.py
@@ -21,14 +21,13 @@ def test_driver_transient_dmp_osc_4():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
 
     # Now generates measured transient signal
     # Last element is ground state

--- a/tests/test_driver_transient_dmp_osc_5.py
+++ b/tests/test_driver_transient_dmp_osc_5.py
@@ -21,14 +21,13 @@ def test_driver_transient_dmp_osc_5():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
 
     # Now generates measured transient signal
     # Last element is ground state

--- a/tests/test_driver_transient_dmp_osc_6.py
+++ b/tests/test_driver_transient_dmp_osc_6.py
@@ -25,14 +25,13 @@ def test_driver_transient_dmp_osc_6():
 
     # set time range (mixed step)
     t_seq1 = np.arange(-2, -1, 0.2)
-    t_seq2 = np.arange(-1, 2, 0.02)
-    t_seq3 = np.arange(2, 5, 0.2)
-    t_seq4 = np.arange(5, 10, 1)
-    t_seq5 = np.arange(10, 100, 10)
-    t_seq6 = np.arange(100, 1000, 100)
-    t_seq7 = np.linspace(1000, 5000, 5)
+    t_seq2 = np.arange(-1, 1, 0.05)
+    t_seq3 = np.arange(1, 20, 0.5)
+    t_seq4 = np.arange(20, 100, 10)
+    t_seq5 = np.arange(100, 2000, 50)
+    t_seq6 = np.linspace(2000, 5000, 4)
 
-    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6, t_seq7))
+    t_seq = np.hstack((t_seq1, t_seq2, t_seq3, t_seq4, t_seq5, t_seq6))
 
     # Now generates measured transient signal
     # Last element is ground state


### PR DESCRIPTION
The test for fitting the driver with models `dmp_osc` and `decay+dmp_osc` failed frequently. I suspect that these test cases are unrealistic. 