### PR TITLE
Add transient parameter layout helper

### DIFF
--- a/src/TRXASprefitpack/driver/_layout.py
+++ b/src/TRXASprefitpack/driver/_layout.py
@@ -1,0 +1,61 @@
+"""
+Helpers for mapping transient fitting parameters to array slices.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class TransientParamLayout:
+    """Layout of a flat transient-fitting parameter vector.
+
+    The layout describes how an optimization parameter vector is divided into
+    IRF, time-zero, and lifetime-related parameter blocks.
+    """
+
+    num_irf: int
+    num_t0: int
+    num_tau: int
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("num_irf", self.num_irf),
+            ("num_t0", self.num_t0),
+            ("num_tau", self.num_tau),
+        ):
+            if not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer.")
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative.")
+
+    @property
+    def irf_slice(self) -> slice:
+        return slice(0, self.num_irf)
+
+    @property
+    def t0_slice(self) -> slice:
+        return slice(self.num_irf, self.num_irf + self.num_t0)
+
+    @property
+    def tau_slice(self) -> slice:
+        start = self.num_irf + self.num_t0
+        return slice(start, start + self.num_tau)
+
+    @property
+    def size(self) -> int:
+        return self.num_irf + self.num_t0 + self.num_tau
+
+    def unpack(self, x: np.ndarray):
+        """Return IRF, t0, and tau blocks from a flat parameter vector."""
+        x = np.asarray(x)
+
+        if x.ndim != 1:
+            raise ValueError("x must be a 1D parameter array.")
+        if x.size != self.size:
+            raise ValueError(
+                f"x has size {x.size}, but this layout expects size {self.size}."
+            )
+
+        return x[self.irf_slice], x[self.t0_slice], x[self.tau_slice]

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pytest
+
+from TRXASprefitpack.driver._layout import TransientParamLayout
+
+
+def test_layout_standard_model():
+    layout = TransientParamLayout(num_irf=1, num_t0=1, num_tau=4)
+
+    assert layout.size == 6
+    assert layout.irf_slice == slice(0, 1)
+    assert layout.t0_slice == slice(1, 2)
+    assert layout.tau_slice == slice(2, 6)
+
+
+def test_layout_unpack():
+    layout = TransientParamLayout(num_irf=2, num_t0=3, num_tau=2)
+    x = np.array([0.5, 0.1, 1.0, 1.1, 1.2, 5.0, 10.0])
+
+    irf, t0, tau = layout.unpack(x)
+
+    np.testing.assert_array_equal(irf, np.array([0.5, 0.1]))
+    np.testing.assert_array_equal(t0, np.array([1.0, 1.1, 1.2]))
+    np.testing.assert_array_equal(tau, np.array([5.0, 10.0]))
+
+
+def test_layout_allows_empty_blocks():
+    layout = TransientParamLayout(num_irf=1, num_t0=0, num_tau=2)
+    x = np.array([0.5, 5.0, 10.0])
+
+    irf, t0, tau = layout.unpack(x)
+
+    np.testing.assert_array_equal(irf, np.array([0.5]))
+    np.testing.assert_array_equal(t0, np.array([]))
+    np.testing.assert_array_equal(tau, np.array([5.0, 10.0]))
+
+
+def test_layout_rejects_short_vector():
+    layout = TransientParamLayout(num_irf=1, num_t0=1, num_tau=2)
+
+    with pytest.raises(ValueError, match="expects size 4"):
+        layout.unpack(np.array([0.5, 1.0, 5.0]))
+
+
+def test_layout_rejects_long_vector():
+    layout = TransientParamLayout(num_irf=1, num_t0=1, num_tau=2)
+
+    with pytest.raises(ValueError, match="expects size 4"):
+        layout.unpack(np.array([0.5, 1.0, 5.0, 10.0, 20.0]))
+
+
+def test_layout_rejects_non_1d_vector():
+    layout = TransientParamLayout(num_irf=1, num_t0=1, num_tau=2)
+
+    with pytest.raises(ValueError, match="1D"):
+        layout.unpack(np.zeros((4, 1)))
+
+
+def test_layout_rejects_negative_block_size():
+    with pytest.raises(ValueError, match="non-negative"):
+        TransientParamLayout(num_irf=1, num_t0=-1, num_tau=2)
+
+
+def test_layout_rejects_non_integer_block_size():
+    with pytest.raises(TypeError, match="integer"):
+        TransientParamLayout(num_irf=1, num_t0=1.5, num_tau=2)


### PR DESCRIPTION
## Summary

This PR adds an internal `TransientParamLayout` helper for slicing flat transient-fitting parameter vectors into IRF, time-zero, and lifetime-related blocks.

## Motivation

Transient fitting parameter vectors have dynamic layouts depending on the number of IRF parameters, time-zero parameters, and lifetime components. This helper provides a safer foundation for replacing hardcoded parameter indexing in future refactors.

## Safety

This PR is purely additive:

- no existing numerical fitting code is modified
- no residual, gradient, Hessian, or convolution code is touched
- no public result object API is changed

## Tests

- `pytest tests/test_layout.py -v`