### PR TITLE
input normalization for transient driver routines

### DIFF
--- a/src/TRXASprefitpack/__init__.py
+++ b/src/TRXASprefitpack/__init__.py
@@ -3,7 +3,7 @@ TRXASprefitpack:
 package for TRXAS pre- and fitting process which aims for the first order dynamics
 TRXAS stands for Time Resolved X-ray Absorption Spectroscopy
 
-:copyright: 2021-2024 by pistack (Junho Lee)
+:copyright: 2021-2026 by pistack (Junho Lee)
 :license: LGPL3.
 '''
 

--- a/src/TRXASprefitpack/driver/_input.py
+++ b/src/TRXASprefitpack/driver/_input.py
@@ -1,0 +1,131 @@
+"""
+Input normalization and validation utilities for transient fitting drivers.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+def _as_dataset_sequence(values, name: str) -> list[np.ndarray]:
+    """Convert a single array or a sequence of arrays into a dataset list."""
+    if values is None:
+        raise ValueError(f"{name} must not be None.")
+
+    if isinstance(values, np.ndarray):
+        return [np.asarray(values)]
+
+    try:
+        return [np.asarray(v) for v in values]
+    except TypeError as exc:
+        raise ValueError(
+            f"{name} must be an array or a sequence of arrays."
+        ) from exc
+
+
+def normalize_tscan_inputs(t, intensity, eps):
+    """Normalize transient scan inputs to driver/residual conventions.
+
+    The residual functions expect each dataset to have the form:
+
+    - t[i]:          shape (n_time,)
+    - intensity[i]:  shape (n_time, n_trace)
+    - eps[i]:        shape (n_time, n_trace)
+
+    A single 1D trace is accepted and converted to shape (n_time, 1).
+    A single dataset array is accepted and converted to a one-element list.
+
+    Parameters
+    ----------
+    t : array-like or sequence of array-like
+        Time axes.
+    intensity : array-like or sequence of array-like
+        Intensity data. Each item may be 1D or 2D.
+    eps : array-like or sequence of array-like
+        Estimated errors. Each item may be 1D or 2D.
+
+    Returns
+    -------
+    tuple[list[np.ndarray], list[np.ndarray], list[np.ndarray]]
+        Normalized ``t``, ``intensity``, and ``eps`` lists.
+    """
+    t_list = _as_dataset_sequence(t, "t")
+    intensity_list = _as_dataset_sequence(intensity, "intensity")
+    eps_list = _as_dataset_sequence(eps, "eps")
+
+    if not (len(t_list) == len(intensity_list) == len(eps_list)):
+        raise ValueError(
+            "t, intensity, and eps must contain the same number of datasets; "
+            f"got {len(t_list)}, {len(intensity_list)}, and {len(eps_list)}."
+        )
+
+    normalized_t = []
+    normalized_intensity = []
+    normalized_eps = []
+
+    for idx, (ti, yi, ei) in enumerate(zip(t_list, intensity_list, eps_list)):
+        ti = np.asarray(ti, dtype=float)
+        yi = np.asarray(yi, dtype=float)
+        ei = np.asarray(ei, dtype=float)
+
+        if ti.ndim != 1:
+            raise ValueError(f"t[{idx}] must be a 1D array.")
+
+        if yi.ndim == 1:
+            yi = yi.reshape(-1, 1)
+        elif yi.ndim != 2:
+            raise ValueError(
+                f"intensity[{idx}] must be a 1D or 2D array; "
+                f"got ndim={yi.ndim}."
+            )
+
+        if ei.ndim == 1:
+            ei = ei.reshape(-1, 1)
+        elif ei.ndim != 2:
+            raise ValueError(
+                f"eps[{idx}] must be a 1D or 2D array; "
+                f"got ndim={ei.ndim}."
+            )
+
+        if yi.shape != ei.shape:
+            raise ValueError(
+                f"intensity[{idx}] and eps[{idx}] must have the same shape; "
+                f"got {yi.shape} and {ei.shape}."
+            )
+
+        if yi.shape[0] != ti.size:
+            raise ValueError(
+                f"intensity[{idx}].shape[0] must match t[{idx}].size; "
+                f"got {yi.shape[0]} and {ti.size}."
+            )
+
+        if np.any(ei <= 0):
+            raise ValueError(f"eps[{idx}] must contain only positive values.")
+
+        normalized_t.append(ti)
+        normalized_intensity.append(yi)
+        normalized_eps.append(ei)
+
+    return normalized_t, normalized_intensity, normalized_eps
+
+
+def expected_t0_count(intensity: Sequence[np.ndarray], same_t0: bool) -> int:
+    """Return the required number of t0 parameters."""
+    if same_t0:
+        return len(intensity)
+
+    return sum(np.asarray(data).shape[1] for data in intensity)
+
+
+def validate_t0_count(t0_init, intensity: Sequence[np.ndarray], same_t0: bool) -> None:
+    """Validate the number of initial t0 parameters."""
+    t0_init = np.atleast_1d(t0_init)
+    expected = expected_t0_count(intensity, same_t0)
+
+    if t0_init.size != expected:
+        raise ValueError(
+            f"t0_init must contain {expected} value(s) for same_t0={same_t0}, "
+            f"got {t0_init.size}."
+        )

--- a/src/TRXASprefitpack/driver/_transient_both.py
+++ b/src/TRXASprefitpack/driver/_transient_both.py
@@ -18,6 +18,7 @@ from ..mathfun.A_matrix import make_A_matrix_exp, make_A_matrix_dmp_osc, fact_an
 from ..res.parm_bound import set_bound_t0, set_bound_tau
 from ..res.res_both import residual_both, res_grad_both
 from ..res.res_both import residual_both_same_t0, res_grad_both_same_t0
+from ._input import normalize_tscan_inputs, validate_t0_count
 
 GLBSOLVER = {'basinhopping': basinhopping, 'ampgo': ampgo}
 
@@ -111,6 +112,9 @@ def fit_transient_both(irf: str, fwhm_init: Union[float, np.ndarray],
         raise Exception('Invalid local least square minimizer solver. It should be one of [trf, lm, dogbox]')
     if irf is not None and irf not in  ['g', 'c', 'pv']:
         raise Exception('Unsupported shape of instrumental response function Edge.')
+
+    t, intensity, eps = normalize_tscan_inputs(t, intensity, eps)
+    validate_t0_count(t0_init, intensity, same_t0)
 
     num_irf = 1*(irf in ['g', 'c'])+2*(irf == 'pv')
     num_param = num_irf+t0_init.size+tau_init.size+2*tau_osc_init.size

--- a/src/TRXASprefitpack/driver/_transient_dmp_osc.py
+++ b/src/TRXASprefitpack/driver/_transient_dmp_osc.py
@@ -17,6 +17,7 @@ from ..mathfun.A_matrix import make_A_matrix_dmp_osc, fact_anal_A
 from ..res.parm_bound import set_bound_t0, set_bound_tau
 from ..res.res_osc import residual_dmp_osc, res_grad_dmp_osc
 from ..res.res_osc import residual_dmp_osc_same_t0, res_grad_dmp_osc_same_t0
+from ._input import normalize_tscan_inputs, validate_t0_count
 
 GLBSOLVER = {'basinhopping': basinhopping, 'ampgo': ampgo}
 
@@ -101,6 +102,9 @@ def fit_transient_dmp_osc(irf: str, fwhm_init: Union[float, np.ndarray],
         raise Exception('Invalid local least square minimizer solver. It should be one of [trf, lm, dogbox]')
     if irf is not None and irf not in  ['g', 'c', 'pv']:
         raise Exception('Unsupported shape of instrumental response function Edge.')
+
+    t, intensity, eps = normalize_tscan_inputs(t, intensity, eps)
+    validate_t0_count(t0_init, intensity, same_t0)
 
     num_comp = tau_init.size
 

--- a/src/TRXASprefitpack/driver/_transient_exp.py
+++ b/src/TRXASprefitpack/driver/_transient_exp.py
@@ -3,21 +3,22 @@ _transient_exp:
 submodule for fitting time delay scan with the
 convolution of sum of exponential decay and instrumental response function
 
-:copyright: 2021-2024 by pistack (Junho Lee).
+:copyright: 2021-2026 by pistack (Junho Lee).
 :license: LGPL3.
 '''
 from typing import Optional, Union, Sequence, Tuple
 import numpy as np
+from scipy.optimize import basinhopping
+from scipy.optimize import least_squares
 from ..mathfun.irf import calc_eta, calc_fwhm
 from .transient_result import TransientResult
 from ._ampgo import ampgo
-from scipy.optimize import basinhopping
-from scipy.optimize import least_squares
 from ..mathfun.A_matrix import make_A_matrix_exp, fact_anal_A
 from ..res.parm_bound import set_bound_t0, set_bound_tau
 from ..res.res_decay import residual_decay, res_grad_decay
 from ..res.res_decay import residual_decay_same_t0, res_grad_decay_same_t0
 from ..res.res_decay import res_hess_decay, res_hess_decay_same_t0
+from ._input import normalize_tscan_inputs, validate_t0_count
 
 GLBSOLVER = {'basinhopping': basinhopping, 'ampgo': ampgo}
 
@@ -102,6 +103,9 @@ def fit_transient_exp(irf: str, fwhm_init: Union[float, np.ndarray],
         raise Exception('Invalid local least square minimizer solver. It should be one of [trf, lm, dogbox]')
     if irf is not None and irf not in  ['g', 'c', 'pv']:
         raise Exception('Unsupported shape of instrumental response function Edge.')
+    
+    t, intensity, eps = normalize_tscan_inputs(t, intensity, eps)
+    validate_t0_count(t0_init, intensity, same_t0)
 
     if tau_init is None:
         num_comp = 0

--- a/src/TRXASprefitpack/driver/_transient_raise.py
+++ b/src/TRXASprefitpack/driver/_transient_raise.py
@@ -8,16 +8,17 @@ convolution of sum of raise model and instrumental response function
 '''
 from typing import Optional, Union, Sequence, Tuple
 import numpy as np
+from scipy.optimize import basinhopping
+from scipy.optimize import least_squares
 from ..mathfun.irf import calc_eta, calc_fwhm
 from .transient_result import TransientResult
 from ._ampgo import ampgo
-from scipy.optimize import basinhopping
-from scipy.optimize import least_squares
 from ..mathfun.A_matrix import make_A_matrix_exp, fact_anal_A
 from ..res.parm_bound import set_bound_t0, set_bound_tau
 from ..res.res_raise import residual_raise, res_grad_raise
 from ..res.res_raise import residual_raise_same_t0, res_grad_raise_same_t0
 from ..res.res_raise import res_hess_raise, res_hess_raise_same_t0
+from ._input import normalize_tscan_inputs, validate_t0_count
 
 GLBSOLVER = {'basinhopping': basinhopping, 'ampgo': ampgo}
 
@@ -99,6 +100,9 @@ def fit_transient_raise(irf: str, fwhm_init: Union[float, np.ndarray],
         raise Exception('Invalid local least square minimizer solver. It should be one of [trf, lm, dogbox]')
     if irf is not None and irf not in  ['g', 'c', 'pv']:
         raise Exception('Unsupported shape of instrumental response function Edge.')
+
+    t, intensity, eps = normalize_tscan_inputs(t, intensity, eps)
+    validate_t0_count(t0_init, intensity, same_t0)
 
     if tau_init is None:
         num_comp = 0

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,5 +1,10 @@
 import numpy as np
 import pytest
+import os
+import sys
+
+path = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(path+'/../src/')
 
 from TRXASprefitpack.driver._layout import TransientParamLayout
 

--- a/tests/test_transient_input.py
+++ b/tests/test_transient_input.py
@@ -1,0 +1,162 @@
+import os
+import sys
+import numpy as np
+import pytest
+
+path = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(path+'/../src/')
+
+from TRXASprefitpack.driver._input import (
+    normalize_tscan_inputs,
+    expected_t0_count,
+    validate_t0_count,
+)
+
+
+def test_normalize_single_1d_trace():
+    t = np.array([0.0, 1.0, 2.0])
+    y = np.array([1.0, 2.0, 3.0])
+    eps = np.array([0.1, 0.1, 0.1])
+
+    t_list, y_list, eps_list = normalize_tscan_inputs(t, y, eps)
+
+    assert len(t_list) == 1
+    assert len(y_list) == 1
+    assert len(eps_list) == 1
+
+    np.testing.assert_allclose(t_list[0], t)
+    assert y_list[0].shape == (3, 1)
+    assert eps_list[0].shape == (3, 1)
+    np.testing.assert_allclose(y_list[0][:, 0], y)
+    np.testing.assert_allclose(eps_list[0][:, 0], eps)
+
+
+def test_normalize_single_2d_dataset():
+    t = np.array([0.0, 1.0, 2.0])
+    y = np.array([[1.0, 1.1], [2.0, 2.1], [3.0, 3.1]])
+    eps = np.full_like(y, 0.1)
+
+    t_list, y_list, eps_list = normalize_tscan_inputs(t, y, eps)
+
+    assert len(t_list) == 1
+    assert y_list[0].shape == (3, 2)
+    assert eps_list[0].shape == (3, 2)
+    np.testing.assert_allclose(y_list[0], y)
+    np.testing.assert_allclose(eps_list[0], eps)
+
+
+def test_normalize_multiple_datasets_with_1d_traces():
+    t = [
+        np.array([0.0, 1.0, 2.0]),
+        np.array([0.0, 0.5, 1.0, 1.5]),
+    ]
+    y = [
+        np.array([1.0, 2.0, 3.0]),
+        np.array([1.0, 1.5, 2.0, 2.5]),
+    ]
+    eps = [
+        np.array([0.1, 0.1, 0.1]),
+        np.array([0.2, 0.2, 0.2, 0.2]),
+    ]
+
+    t_list, y_list, eps_list = normalize_tscan_inputs(t, y, eps)
+
+    assert len(t_list) == 2
+    assert y_list[0].shape == (3, 1)
+    assert y_list[1].shape == (4, 1)
+    assert eps_list[0].shape == (3, 1)
+    assert eps_list[1].shape == (4, 1)
+
+
+def test_reject_mismatched_dataset_count():
+    t = [np.array([0.0, 1.0])]
+    y = [np.array([1.0, 2.0]), np.array([3.0, 4.0])]
+    eps = [np.array([0.1, 0.1])]
+
+    with pytest.raises(ValueError, match="same number of datasets"):
+        normalize_tscan_inputs(t, y, eps)
+
+
+def test_reject_non_1d_time_axis():
+    t = np.array([[0.0, 1.0]])
+    y = np.array([1.0, 2.0])
+    eps = np.array([0.1, 0.1])
+
+    with pytest.raises(ValueError, match=r"t\[0\] must be a 1D array"):
+        normalize_tscan_inputs(t, y, eps)
+
+
+def test_reject_mismatched_intensity_eps_shape():
+    t = np.array([0.0, 1.0, 2.0])
+    y = np.array([1.0, 2.0, 3.0])
+    eps = np.array([[0.1, 0.1], [0.1, 0.1], [0.1, 0.1]])
+
+    with pytest.raises(ValueError, match="must have the same shape"):
+        normalize_tscan_inputs(t, y, eps)
+
+
+def test_reject_mismatched_time_length():
+    t = np.array([0.0, 1.0])
+    y = np.array([1.0, 2.0, 3.0])
+    eps = np.array([0.1, 0.1, 0.1])
+
+    with pytest.raises(ValueError, match=r"shape\[0\] must match"):
+        normalize_tscan_inputs(t, y, eps)
+
+
+def test_reject_nonpositive_eps():
+    t = np.array([0.0, 1.0, 2.0])
+    y = np.array([1.0, 2.0, 3.0])
+    eps = np.array([0.1, 0.0, 0.1])
+
+    with pytest.raises(ValueError, match="positive"):
+        normalize_tscan_inputs(t, y, eps)
+
+
+def test_expected_t0_count_scanwise():
+    intensity = [
+        np.zeros((10, 2)),
+        np.zeros((8, 3)),
+    ]
+
+    assert expected_t0_count(intensity, same_t0=False) == 5
+
+
+def test_expected_t0_count_same_t0():
+    intensity = [
+        np.zeros((10, 2)),
+        np.zeros((8, 3)),
+    ]
+
+    assert expected_t0_count(intensity, same_t0=True) == 2
+
+
+def test_validate_t0_count_scanwise_passes():
+    intensity = [
+        np.zeros((10, 2)),
+        np.zeros((8, 3)),
+    ]
+    t0_init = np.zeros(5)
+
+    validate_t0_count(t0_init, intensity, same_t0=False)
+
+
+def test_validate_t0_count_same_t0_passes():
+    intensity = [
+        np.zeros((10, 2)),
+        np.zeros((8, 3)),
+    ]
+    t0_init = np.zeros(2)
+
+    validate_t0_count(t0_init, intensity, same_t0=True)
+
+
+def test_validate_t0_count_raises():
+    intensity = [
+        np.zeros((10, 2)),
+        np.zeros((8, 3)),
+    ]
+    t0_init = np.zeros(4)
+
+    with pytest.raises(ValueError, match="t0_init must contain 5"):
+        validate_t0_count(t0_init, intensity, same_t0=False)


### PR DESCRIPTION
This normalizes a tuple containing a list of time-delay points, a list of intensities, and a list of the estimated errors for each intensity dataset for transient driver routines, and validates the number of time zeros. 